### PR TITLE
chore: fix go.mod

### DIFF
--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-google-modules//test/integration
+module github.com/terraform-google-modules/terraform-google-analytics-lakehouse/test/integration
 
 go 1.18
 


### PR DESCRIPTION
This should have been filled in with `{{cookiecutter.module_name}}`