### PR TITLE
fix: set staging and temp bucket for phs cluster

### DIFF
--- a/dataproc.tf
+++ b/dataproc.tf
@@ -109,6 +109,8 @@ resource "google_dataproc_cluster" "phs" {
   project = module.project-services.project_id
   region  = var.region
   cluster_config {
+    staging_bucket = google_storage_bucket.phs-staging-bucket.name
+    temp_bucket    = google_storage_bucket.phs-temp-bucket.name
     gce_cluster_config {
       service_account = google_service_account.dataproc_service_account.email
       subnetwork      = google_compute_subnetwork.subnet.name

--- a/main.tf
+++ b/main.tf
@@ -171,3 +171,19 @@ resource "google_storage_bucket" "spark-log-directory" {
   uniform_bucket_level_access = true
   force_destroy               = var.force_destroy
 }
+
+resource "google_storage_bucket" "phs-staging-bucket" {
+  name                        = "gcp-${var.use_case_short}-phs-staging-${random_id.id.hex}"
+  project                     = module.project-services.project_id
+  location                    = var.region
+  uniform_bucket_level_access = true
+  force_destroy               = var.force_destroy
+}
+
+resource "google_storage_bucket" "phs-temp-bucket" {
+  name                        = "gcp-${var.use_case_short}-phs-temp-${random_id.id.hex}"
+  project                     = module.project-services.project_id
+  location                    = var.region
+  uniform_bucket_level_access = true
+  force_destroy               = var.force_destroy
+}


### PR DESCRIPTION
Added staging and temp buckets under terraform configuration so that they can be deleted by `terraform destroy` command.