### PR TITLE
fix: remove compute instance check from integration test teardown

### DIFF
--- a/test/integration/analytics_lakehouse/analytics_lakehouse_test.go
+++ b/test/integration/analytics_lakehouse/analytics_lakehouse_test.go
@@ -91,19 +91,6 @@ func TestAnalyticsLakehouse(t *testing.T) {
 	})
 
 	dwh.DefineTeardown(func(assert *assert.Assertions) {
-
-		projectID := dwh.GetTFSetupStringOutput("project_id")
-
-		verifyNoVMs := func() (bool, error) {
-			currentComputeInstances := gcloud.Runf(t, "compute instances list --project %s", projectID).Array()
-			// If compute instances is greater than 0, wait and check again until 0 to complete destroy
-			if len(currentComputeInstances) > 0 {
-				return true, nil
-			}
-			return false, nil
-		}
-		utils.Poll(t, verifyNoVMs, 120, 30*time.Second)
-
 		dwh.DefaultTeardown(assert)
 
 	})


### PR DESCRIPTION
Removing check for compute instances that was relevant when we were using Dataproc Serverless