### PR TITLE
fix: delete dataproc session with its template

### DIFF
--- a/src/ipynb/spark_ml.ipynb
+++ b/src/ipynb/spark_ml.ipynb
@@ -34,7 +34,7 @@
    "source": [
     "## Tutorial\n",
     "\n",
-    "### Set your project ID and location"
+    "### Set your project ID, location, and session ID"
    ]
   },
   {
@@ -54,7 +54,11 @@
     "\n",
     "# Retrieve the current location.\n",
     "LOCATION = !gcloud compute instances list --project={PROJECT_ID} --format='get(ZONE)'\n",
-    "LOCATION = str(LOCATION).split(\"/\")[-1][:-4]"
+    "LOCATION = str(LOCATION).split(\"/\")[-1][:-4]\n",
+    "\n",
+    "# Get the name of active Dataproc Interactive Session\n",
+    "SESSION = !gcloud beta dataproc sessions list --location='{LOCATION}' --filter='state=ACTIVE' --format='get(SESSION_ID)' --sort-by='~createTime'\n",
+    "SESSION = SESSION[0].split('/')[-1] if SESSION else None"
    ]
   },
   {
@@ -645,7 +649,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Delete the Dataproc session template\n",
+    "### Delete the Dataproc session and the session template\n",
     "\n",
     "To delete the running Dataproc Serverless session, run the following command."
    ]
@@ -656,7 +660,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gcloud beta dataproc session-templates delete sparkml-template --location='{LOCATION}' --quiet"
+    "# Delete the session teamplate\n",
+    "!gcloud beta dataproc session-templates delete sparkml-template --location='{LOCATION}' --quiet\n",
+    "\n",
+    "# Delete the Dataproc Interactive Session if session is existed\n",
+    "if SESSION:\n",
+    "    !gcloud beta dataproc sessions terminate '{SESSION}' --location='{LOCATION}' --quiet"
    ]
   }
  ],

--- a/src/ipynb/spark_ml.ipynb
+++ b/src/ipynb/spark_ml.ipynb
@@ -56,7 +56,7 @@
     "LOCATION = !gcloud compute instances list --project={PROJECT_ID} --format='get(ZONE)'\n",
     "LOCATION = str(LOCATION).split(\"/\")[-1][:-4]\n",
     "\n",
-    "# Get the name of the active Dataproc Interactive Session\n",
+    "# Get the name of the active Dataproc Serverless Session\n",
     "SESSION = !gcloud beta dataproc sessions list --location='{LOCATION}' --filter='state=ACTIVE' --format='get(SESSION_ID)' --sort-by='~createTime'\n",
     "SESSION = SESSION[0].split('/')[-1] if SESSION else None"
    ]
@@ -664,7 +664,7 @@
     "# Delete the session template\n",
     "!gcloud beta dataproc session-templates delete sparkml-template --location='{LOCATION}' --quiet\n",
     "\n",
-    "# Delete the Dataproc Interactive Session if session exists\n",
+    "# Delete the Dataproc Serverless Session if session exists\n",
     "if SESSION:\n",
     "    !gcloud beta dataproc sessions terminate '{SESSION}' --location='{LOCATION}' --quiet"
    ]

--- a/src/ipynb/spark_ml.ipynb
+++ b/src/ipynb/spark_ml.ipynb
@@ -56,7 +56,7 @@
     "LOCATION = !gcloud compute instances list --project={PROJECT_ID} --format='get(ZONE)'\n",
     "LOCATION = str(LOCATION).split(\"/\")[-1][:-4]\n",
     "\n",
-    "# Get the name of active Dataproc Interactive Session\n",
+    "# Get the name of the active Dataproc Interactive Session\n",
     "SESSION = !gcloud beta dataproc sessions list --location='{LOCATION}' --filter='state=ACTIVE' --format='get(SESSION_ID)' --sort-by='~createTime'\n",
     "SESSION = SESSION[0].split('/')[-1] if SESSION else None"
    ]
@@ -651,7 +651,8 @@
    "source": [
     "### Delete the Dataproc session and the session template\n",
     "\n",
-    "To delete the running Dataproc Serverless session, run the following command."
+    "To delete the running Dataproc Serverless session, run the following command.\n",
+    "If you've completed this tutorial as part of the [Analytics Lakehouse](https://console.cloud.google.com/products/solutions/details/analytics-lakehouse) solution, you will need to proceed with this step before deleting the solution from your project."
    ]
   },
   {
@@ -660,10 +661,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Delete the session teamplate\n",
+    "# Delete the session template\n",
     "!gcloud beta dataproc session-templates delete sparkml-template --location='{LOCATION}' --quiet\n",
     "\n",
-    "# Delete the Dataproc Interactive Session if session is existed\n",
+    "# Delete the Dataproc Interactive Session if session exists\n",
     "if SESSION:\n",
     "    !gcloud beta dataproc sessions terminate '{SESSION}' --location='{LOCATION}' --quiet"
    ]


### PR DESCRIPTION
The SparkML notebook deletes only the Dataproc Serverless Template session, not the session itself. Since the Dataproc Interactive session uses subnet, deleting the JSS while the session is active causes an error.

This PR terminates the Dataproc Session at the end of the notebook so that it makes destroying JSS successfully.