### PR TITLE
fix: update workbench.tf to deploy in 'b' zones

### DIFF
--- a/workbench.tf
+++ b/workbench.tf
@@ -39,7 +39,7 @@ resource "google_project_iam_member" "workbench_sa_roles" {
 resource "google_workbench_instance" "workbench_instance" {
   name          = "gcp-${var.use_case_short}-workbench-instance-${random_id.id.hex}"
   project       = module.project-services.project_id
-  location      = "${var.region}-a"
+  location      = "${var.region}-b"
   desired_state = "STOPPED"
 
   gce_setup {


### PR DESCRIPTION
Some regions do not contain the `a` zone but all contain a `b` zone. Deploy Workbench instance to `b` zones always (this is difficult to otherwise dynamically configure).