### PR TITLE
chore: update release-please.yml

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -14,3 +14,4 @@
 
 releaseType: terraform-module
 handleGHRelease: true
+bumpMinorPreMajor: true


### PR DESCRIPTION
We generally don't bump the major from v0.x.x releases.