### PR TITLE
Rename 'goog-' labels to 'cv-' and add validation rules

### DIFF
--- a/dataplex.tf
+++ b/dataplex.tf
@@ -201,6 +201,12 @@ resource "google_dataplex_datascan" "dq_scan" {
   location     = var.region
   data_scan_id = "thelook-ecommerce-orders"
 
+  # Rename labels starting with 'goog-' to 'cv-' to bypass API restrictions
+  labels = {
+    for k, v in var.labels : 
+    (startswith(k, "goog-") ? replace(k, "goog-", "cv-") : k) => v
+  }
+
   data {
     resource = "//bigquery.googleapis.com/projects/${module.project-services.project_id}/datasets/${local.datascan_dataset}/tables/thelook_ecommerce_orders"
   }
@@ -220,7 +226,6 @@ resource "google_dataplex_datascan" "dq_scan" {
       threshold   = 1.0
       non_null_expectation {}
     }
-
     rules {
       column      = "user_id"
       dimension   = "COMPLETENESS"
@@ -229,7 +234,6 @@ resource "google_dataplex_datascan" "dq_scan" {
       threshold   = 1.0
       non_null_expectation {}
     }
-
     rules {
       column      = "created_at"
       dimension   = "COMPLETENESS"
@@ -238,7 +242,6 @@ resource "google_dataplex_datascan" "dq_scan" {
       threshold   = 1.0
       non_null_expectation {}
     }
-
     rules {
       column      = "order_id"
       dimension   = "UNIQUENESS"
@@ -246,7 +249,6 @@ resource "google_dataplex_datascan" "dq_scan" {
       description = "Sample rule for values in a set"
       uniqueness_expectation {}
     }
-
     rules {
       column      = "status"
       dimension   = "VALIDITY"
@@ -256,6 +258,32 @@ resource "google_dataplex_datascan" "dq_scan" {
       set_expectation {
         values = ["Shipped", "Complete", "Processing", "Cancelled", "Returned"]
       }
+    }
+    rules {
+      column      = "num_of_item"
+      dimension   = "VALIDITY"
+      name        = "range-values"
+      description = "Sample rule for values in a range"
+      ignore_null = false
+      threshold   = 0.99
+      range_expectation {
+        max_value          = 1
+        strict_max_enabled = false
+        strict_min_enabled = false
+      }
+    }
+    rules {
+      dimension   = "VALIDITY"
+      name        = "non-empty-table"
+      description = "Sample rule for a non-empty table"
+      table_condition_expectation {
+        sql_expression = "COUNT(*) > 0"
+      }
+    }
+  }
+
+  depends_on = [time_sleep.wait_for_dataplex_discovery]
+}
     }
 
     rules {
@@ -284,3 +312,5 @@ resource "google_dataplex_datascan" "dq_scan" {
 
   depends_on = [time_sleep.wait_for_dataplex_discovery]
 }
+
+fix: sanitize goog- labels


### PR DESCRIPTION
Added logic to rename labels starting with 'goog-' to 'cv-' to comply with API restrictions. Introduced new rules for 'num_of_item' and a non-empty table condition.